### PR TITLE
Add recitation follow-along (listen & jump to ayah) to the Quran reader

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "qiraathub-dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,31 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Recitation follow-along (Quran page)
+
+The Quran reader (`/quran`) has a Tarteel-style follow-along mode: press the
+mic button, recite, and the reader detects the ayah being recited, jumps to
+its page, highlights it word-by-word and keeps scrolling with the reciter.
+
+- Speech capture uses the browser's Web Speech API (Chrome/Edge/Safari;
+  Arabic `ar-SA`). No audio leaves the app besides the browser's own speech
+  service.
+- Matching runs entirely client-side: the loaded mushaf data (per qiraat) is
+  indexed word-by-word (`app/quran/recitation/indexer.ts`), speech is
+  normalized to a diacritic-free skeleton that bridges Uthmani script and
+  recognizer orthography (`arabic.ts`), and a tracker locks onto and follows
+  the recitation, tolerating recognition noise, isti'adha/basmallah, and the
+  Quran's many repeated phrases (`engine.ts`).
+- The engine and indexer are covered by a test suite that runs against the
+  real mushaf data:
+
+```bash
+pnpm test:recitation
+```
+
+For manual testing without a microphone, set `window.__qhFakeSpeechCtor` to a
+scripted `SpeechRecognition` substitute before pressing the mic button (see
+`app/quran/recitation/speech.ts`).
+
 ## Getting Started
 
 First, run the development server:

--- a/app/quran/page.tsx
+++ b/app/quran/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useMemo } from "react";
+import { useEffect, useState, useCallback, useMemo, memo } from "react";
 import "./styles.css";
 import { FaSpinner, FaSun, FaMoon, FaCog } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
@@ -9,9 +9,15 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
-import { BookOpen, Search, Check } from "lucide-react";
+import { BookOpen, Search, Check, Mic, MicOff, X } from "lucide-react";
 import { allSurahs, SurahInfo } from "@/app/lib/surah-definitions";
 import { cn } from "@/lib/utils";
+import { normalizeArabicWord } from "./recitation/arabic";
+import { buildRecitationIndex, type RecitationIndex } from "./recitation/indexer";
+import {
+  useRecitationFollower,
+  type FollowerSnapshot,
+} from "./recitation/useRecitationFollower";
 
 interface PageContent {
   html_content: string;
@@ -130,6 +136,163 @@ function Basmallah() {
   return <div className="bismillah text-center flex justify-center"> ﷽</div>;
 }
 
+interface QuranLineProps {
+  line: Extract<ParsedLine, { kind: "quran_line" }>;
+  /** Recited-ayah highlight range clipped to this line (span ids), or null. */
+  hlStart: number | null;
+  hlEnd: number | null;
+  hlWord: number | null;
+}
+
+/**
+ * One mushaf line. Span ids are assigned the way the source data numbers
+ * them: sequentially from data-first-word-id across words and ayah markers,
+ * skipping spans that hold only waqf marks — mirroring the recitation
+ * indexer so highlight id ranges line up exactly.
+ */
+const QuranLine = memo(function QuranLine({ line, hlStart, hlEnd, hlWord }: QuranLineProps) {
+  const alignmentClass = line.isCentered
+    ? "text-center flex justify-center"
+    : "flex justify-between";
+  let nextId = line.firstWordId ? parseInt(line.firstWordId, 10) : null;
+  return (
+    <p
+      className={`quran-line ${alignmentClass}`}
+      data-pag={line.pageNumber ?? undefined}
+      data-line={line.lineNumber ?? undefined}
+      data-first-word-id={line.firstWordId ?? undefined}
+      data-last-word-id={line.lastWordId ?? undefined}
+      id={line.lineId ?? undefined}
+    >
+      {line.words.map((wordData, wordIndex) => {
+        let spanId: number | null = null;
+        if (nextId !== null) {
+          if (wordData.kind === "marker" || normalizeArabicWord(wordData.text)) {
+            spanId = nextId;
+            nextId++;
+          }
+        }
+        const inAyah =
+          spanId !== null && hlStart !== null && hlEnd !== null &&
+          spanId >= hlStart && spanId <= hlEnd;
+        const isCurrent = spanId !== null && hlWord !== null && spanId === hlWord;
+        if (wordData.kind === "marker") {
+          return (
+            <span
+              key={wordIndex}
+              className={cn("arabic-num-marker", inAyah && "recited-ayah")}
+              data-wid={spanId ?? undefined}
+            >
+              {wordData.text}
+            </span>
+          );
+        }
+        return (
+          <span
+            key={wordIndex}
+            className={cn(
+              "word",
+              wordData.ayahClass,
+              inAyah && "recited-ayah",
+              isCurrent && "recited-word"
+            )}
+            data-wid={spanId ?? undefined}
+          >
+            <span
+              className="text"
+              style={wordData.isRed ? { color: "red" } : undefined}
+            >
+              {wordData.text}
+            </span>
+          </span>
+        );
+      })}
+    </p>
+  );
+});
+
+function ListeningPill({
+  snapshot,
+  onStop,
+  onDismissError,
+}: {
+  snapshot: FollowerSnapshot;
+  onStop: () => void;
+  onDismissError: () => void;
+}) {
+  if (snapshot.status === "idle") return null;
+
+  if (snapshot.status === "error") {
+    return (
+      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 max-w-[92vw]">
+        <div className="flex items-center gap-3 rounded-full bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-200 shadow-lg px-4 py-2 text-sm">
+          <span>{snapshot.error}</span>
+          <button
+            onClick={onDismissError}
+            className="shrink-0 rounded-full p-1 hover:bg-red-100 dark:hover:bg-red-900"
+            aria-label="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const locked = snapshot.phase === "locked" && snapshot.surah !== null;
+  const surahName = locked
+    ? allSurahs[(snapshot.surah as number) - 1]?.name ?? `Surah ${snapshot.surah}`
+    : null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 max-w-[92vw]">
+      <div className="flex items-center gap-3 rounded-full bg-white/95 dark:bg-gray-800/95 backdrop-blur border shadow-lg px-4 py-2">
+        <span className="relative flex h-3 w-3 shrink-0">
+          <span
+            className={cn(
+              "animate-ping absolute inline-flex h-full w-full rounded-full opacity-60",
+              locked ? "bg-green-500" : "bg-red-400"
+            )}
+          />
+          <span
+            className={cn(
+              "relative inline-flex rounded-full h-3 w-3",
+              locked ? "bg-green-500" : "bg-red-500"
+            )}
+          />
+        </span>
+        <div className="flex flex-col min-w-0">
+          <span className="text-sm font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">
+            {snapshot.status === "preparing"
+              ? "Preparing…"
+              : locked
+                ? `${surahName} · Ayah ${snapshot.ayah}`
+                : !snapshot.micActive
+                  ? "Waiting for microphone…"
+                  : "Listening — recite to locate…"}
+          </span>
+          {snapshot.tail && (
+            <span
+              dir="rtl"
+              className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[16rem]"
+            >
+              {snapshot.tail}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={onStop}
+          className="shrink-0 rounded-full p-1.5 hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+          aria-label="Stop listening"
+          title="Stop listening"
+        >
+          <MicOff className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function QuranReader() {
   const [quranData, setQuranData] = useState<QuranData>({});
   const [loading, setLoading] = useState(true);
@@ -188,6 +351,70 @@ export default function QuranReader() {
     () => (pageContent?.notes_content ? parseQuranNotes(pageContent.notes_content) : []),
     [pageContent]
   );
+
+  // --- Recitation follow-along (listen & jump to the recited ayah) ---
+  const [listenRequested, setListenRequested] = useState(false);
+  const [recitationIndex, setRecitationIndex] = useState<RecitationIndex | null>(null);
+
+  // Build the index lazily on first use and rebuild when the mushaf data
+  // (qiraat/font) changes, so matching always follows the displayed text.
+  useEffect(() => {
+    setRecitationIndex(null);
+    if (!listenRequested || loading || Object.keys(quranData).length === 0) return;
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      if (!cancelled) setRecitationIndex(buildRecitationIndex(quranData));
+    }, 50);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [listenRequested, quranData, loading]);
+
+  const { snapshot, listening, start: startListening, stop: stopListening } =
+    useRecitationFollower(recitationIndex);
+
+  const toggleListening = useCallback(() => {
+    if (listening) {
+      stopListening();
+    } else {
+      setListenRequested(true);
+      startListening();
+    }
+  }, [listening, startListening, stopListening]);
+
+  // Jump to the detected ayah's page whenever the detected position moves.
+  useEffect(() => {
+    if (snapshot.phase !== "locked" || snapshot.page === null) return;
+    setPageNumber((prev) => (prev === snapshot.page ? prev : (snapshot.page as number)));
+  }, [snapshot.phase, snapshot.page, snapshot.surah, snapshot.ayah]);
+
+  // Keep the recited word in view as it advances. Scrolls are instant:
+  // smooth animations get canceled/paused by per-word re-renders and
+  // background tabs, so they can silently never arrive. The delayed
+  // re-check corrects for layout shifts (font loading) right after a page
+  // change; both calls no-op while the word is already in the band.
+  useEffect(() => {
+    if (snapshot.phase !== "locked" || snapshot.wordId === null || loading) return;
+    const ensureVisible = () => {
+      const el = document.querySelector(`[data-wid="${snapshot.wordId}"]`);
+      if (!el) return;
+      const viewportH = Math.max(
+        window.innerHeight || 0,
+        document.documentElement.clientHeight || 0
+      );
+      if (viewportH === 0) return;
+      const rect = el.getBoundingClientRect();
+      if (rect.top >= 100 && rect.bottom <= viewportH - 140) return;
+      el.scrollIntoView({ behavior: "auto", block: "center" });
+    };
+    const raf = requestAnimationFrame(ensureVisible);
+    const recheck = setTimeout(ensureVisible, 500);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(recheck);
+    };
+  }, [snapshot.wordId, snapshot.phase, loading, pageNumber]);
 
   const handleNextPage = useCallback(() => {
     setPageNumber((prev) => Math.min(prev + 1, totalPages));
@@ -373,7 +600,25 @@ export default function QuranReader() {
             <Button onClick={handlePreviousPage} disabled={pageNumber === 1} variant="outline">
               Previous &rarr;
             </Button>
-            <Button onClick={toggleDarkMode} variant="ghost" size="icon" className="ml-4">
+            <Button
+              onClick={toggleListening}
+              className={cn(
+                "ml-4 gap-2 font-semibold text-white shadow-md",
+                listening
+                  ? "bg-red-600 hover:bg-red-700 animate-pulse"
+                  : "bg-emerald-600 hover:bg-emerald-700"
+              )}
+              title={
+                listening
+                  ? "Stop follow-along"
+                  : "Recite and the reader finds the ayah and follows along"
+              }
+              aria-label={listening ? "Stop follow-along" : "Start follow-along"}
+            >
+              {listening ? <MicOff className="h-5 w-5" /> : <Mic className="h-5 w-5" />}
+              <span>{listening ? "Listening…" : "Follow along"}</span>
+            </Button>
+            <Button onClick={toggleDarkMode} variant="ghost" size="icon">
               {isDarkMode ? <FaSun className="h-5 w-5" /> : <FaMoon className="h-5 w-5" />}
             </Button>
             <Popover>
@@ -439,42 +684,37 @@ export default function QuranReader() {
                         if (line.kind === "basmallah") {
                           return <Basmallah key={index} />;
                         }
-                        const alignmentClass = line.isCentered
-                          ? "text-center flex justify-center"
-                          : "flex justify-between";
+                        // Clip the recited-ayah highlight to this line so
+                        // unaffected lines keep stable props (memo skips them).
+                        let hlStart: number | null = null;
+                        let hlEnd: number | null = null;
+                        let hlWord: number | null = null;
+                        if (
+                          snapshot.phase === "locked" &&
+                          snapshot.ayahStartId !== null &&
+                          snapshot.ayahEndId !== null &&
+                          line.firstWordId &&
+                          line.lastWordId
+                        ) {
+                          const lineFirst = parseInt(line.firstWordId, 10);
+                          const lineLast = parseInt(line.lastWordId, 10);
+                          if (
+                            snapshot.ayahStartId <= lineLast &&
+                            snapshot.ayahEndId >= lineFirst
+                          ) {
+                            hlStart = snapshot.ayahStartId;
+                            hlEnd = snapshot.ayahEndId;
+                            hlWord = snapshot.wordId;
+                          }
+                        }
                         return (
-                          <p
+                          <QuranLine
                             key={index}
-                            className={`quran-line ${alignmentClass}`}
-                            data-pag={line.pageNumber ?? undefined}
-                            data-line={line.lineNumber ?? undefined}
-                            data-first-word-id={line.firstWordId ?? undefined}
-                            data-last-word-id={line.lastWordId ?? undefined}
-                            id={line.lineId ?? undefined}
-                          >
-                            {line.words.map((wordData, wordIndex) => {
-                              if (wordData.kind === "marker") {
-                                return (
-                                  <span key={wordIndex} className="arabic-num-marker">
-                                    {wordData.text}
-                                  </span>
-                                );
-                              }
-                              return (
-                                <span
-                                  key={wordIndex}
-                                  className={`word ${wordData.ayahClass}`.trim()}
-                                >
-                                  <span
-                                    className="text"
-                                    style={wordData.isRed ? { color: "red" } : undefined}
-                                  >
-                                    {wordData.text}
-                                  </span>
-                                </span>
-                              );
-                            })}
-                          </p>
+                            line={line}
+                            hlStart={hlStart}
+                            hlEnd={hlEnd}
+                            hlWord={hlWord}
+                          />
                         );
                       })}
                     </div>
@@ -504,6 +744,11 @@ export default function QuranReader() {
           </Card>
         </main>
       </div>
+      <ListeningPill
+        snapshot={snapshot}
+        onStop={toggleListening}
+        onDismissError={stopListening}
+      />
     </div>
     </div>
   );

--- a/app/quran/recitation/arabic.ts
+++ b/app/quran/recitation/arabic.ts
@@ -1,0 +1,112 @@
+/**
+ * Arabic text normalization and fuzzy matching utilities for recitation
+ * following. Maps both Uthmani-script mushaf text and speech-recognition
+ * output (standard orthography) into a common skeleton so they can be
+ * compared word-by-word.
+ */
+
+// Characters mapped to a plain-letter equivalent before stripping marks.
+// Dagger alef (U+0670) and small waw/yeh represent full long vowels in the
+// Uthmani script (e.g. ٱلصِّرَٰطَ -> الصراط), so they become real letters
+// rather than being dropped.
+const CHAR_MAP: Record<string, string> = {
+  "آ": "ا", // آ  alef madda -> alef
+  "أ": "ا", // أ  alef hamza above -> alef
+  "إ": "ا", // إ  alef hamza below -> alef
+  "ٱ": "ا", // ٱ  alef wasla -> alef
+  "ٲ": "ا", // ٲ  alef wavy hamza above -> alef
+  "ٳ": "ا", // ٳ  alef wavy hamza below -> alef
+  "ٰ": "ا", // ٰ  dagger alef -> alef
+  "ؤ": "و", // ؤ  waw hamza -> waw
+  "ۥ": "و", // ۥ  small waw -> waw
+  "ئ": "ي", // ئ  yeh hamza -> yeh
+  "ى": "ي", // ى  alef maqsura -> yeh
+  "ی": "ي", // ی  farsi yeh -> yeh
+  "ۦ": "ي", // ۦ  small yeh -> yeh
+  "ۧ": "ي", // ۧ  small high yeh -> yeh (e.g. إبرٰهـۧم)
+  "ۨ": "ن", // ۨ  small high noon -> noon (e.g. نـۨجي)
+  "ة": "ه", // ة  ta marbuta -> ha
+  "ک": "ك", // ک  keheh -> kaf
+  "ء": "", // ء  standalone hamza dropped
+  "ـ": "", // ـ  tatweel dropped
+};
+
+// Arabic letters we keep after mapping (the base alphabet block).
+const KEEP_RE = /[ا-ي]/;
+
+/**
+ * Normalize an Arabic word (or phrase) to a diacritic-free skeleton in
+ * standard orthography. Anything that is not an Arabic letter after
+ * mapping (harakat, quranic annotation signs, digits, latin, punctuation)
+ * is removed. Whitespace is NOT preserved — use tokenizeArabic for text.
+ */
+export function normalizeArabicWord(input: string): string {
+  let out = "";
+  for (const ch of input) {
+    const mapped = CHAR_MAP[ch];
+    if (mapped !== undefined) {
+      out += mapped;
+      continue;
+    }
+    if (KEEP_RE.test(ch)) {
+      out += ch;
+    }
+    // everything else (tashkeel, quranic marks, digits, symbols) dropped
+  }
+  return out;
+}
+
+/** Split free text into normalized, non-empty word tokens. */
+export function tokenizeArabic(text: string): string[] {
+  const tokens: string[] = [];
+  for (const raw of text.split(/\s+/)) {
+    const norm = normalizeArabicWord(raw);
+    if (norm) tokens.push(norm);
+  }
+  return tokens;
+}
+
+/** Classic Levenshtein distance (iterative, two-row). */
+export function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  const la = a.length;
+  const lb = b.length;
+  if (la === 0) return lb;
+  if (lb === 0) return la;
+  let prev = new Array<number>(lb + 1);
+  let curr = new Array<number>(lb + 1);
+  for (let j = 0; j <= lb; j++) prev[j] = j;
+  for (let i = 1; i <= la; i++) {
+    curr[0] = i;
+    const ca = a.charCodeAt(i - 1);
+    for (let j = 1; j <= lb; j++) {
+      const cost = ca === b.charCodeAt(j - 1) ? 0 : 1;
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[lb];
+}
+
+/** Similarity in [0,1] between two normalized words. */
+export function wordSimilarity(a: string, b: string): number {
+  if (a === b) return 1;
+  const m = Math.max(a.length, b.length);
+  if (m === 0) return 0;
+  return 1 - levenshtein(a, b) / m;
+}
+
+/**
+ * Whether a spoken word is an acceptable match for an expected word.
+ * Tolerance scales with length; very short words must match exactly to
+ * avoid noise from common particles (من/ما/لا...).
+ */
+export function isWordMatch(spoken: string, expected: string): boolean {
+  if (spoken === expected) return true;
+  const m = Math.max(spoken.length, expected.length);
+  if (m <= 3) return false; // short words: exact only
+  const dist = levenshtein(spoken, expected);
+  if (m <= 6) return dist <= 1;
+  if (m <= 9) return dist <= 2;
+  return dist <= 3;
+}

--- a/app/quran/recitation/engine.ts
+++ b/app/quran/recitation/engine.ts
@@ -1,0 +1,367 @@
+/**
+ * Recitation tracker: aligns a growing speech transcript against the mushaf
+ * word index. Works like a follow-along engine (Tarteel-style):
+ *
+ *  - searching: buffer spoken words, locate them globally via an inverted
+ *    index + fuzzy sequence alignment. Locks only when one location clearly
+ *    wins (guards against the Quran's many repeated phrases).
+ *  - locked: follow word-by-word within a small lookahead window; tolerate
+ *    recognition noise; consume isti'adha/basmallah silently; after several
+ *    consecutive misses fall back to searching (reciter jumped elsewhere).
+ *
+ * The tracker is fed the full final transcript plus the volatile interim
+ * tail on every recognition event. Final words advance persistent state;
+ * interim words are applied to a throwaway copy so their churn never
+ * corrupts tracking.
+ */
+
+import { isWordMatch, tokenizeArabic, wordSimilarity } from "./arabic";
+import type { AyahInfo, IndexedWord, RecitationIndex } from "./indexer";
+import { ayahKey } from "./indexer";
+
+export type TrackerPhase = "searching" | "locked";
+
+export interface TrackerResult {
+  phase: TrackerPhase;
+  word: IndexedWord | null;
+  ayah: AyahInfo | null;
+}
+
+const LOOKAHEAD = 10; // follow-mode window size (words ahead of anchor)
+const MAX_MISSES = 5; // consecutive misses before falling back to search
+const SEARCH_BUF_MAX = 10;
+const MISS_BUF_MAX = 8;
+const MIN_LOCK_MATCHES = 3;
+const MIN_LOCK_RATIO = 0.6; // aligned fraction of buffered words
+const MIN_LOCK_AVG_SIM = 0.72;
+const LOCK_MARGIN = 0.12; // required lead over 2nd-best location
+const SEED_DF_CAP = 700; // words more frequent than this don't seed search
+const CANDIDATE_CAP = 6000;
+const ALIGN_SKIP = 2; // index words the aligner may hop over per spoken word
+const SAME_REGION_SEQS = 8; // candidates this close are the same location
+// Cold-start prior: people overwhelmingly start reciting at a surah opening,
+// which disambiguates phrases like الحمد لله رب العالمين (Fatiha vs 5 other
+// verbatim occurrences deep inside other suwar).
+const SURAH_OPENING_BONUS_NEAR = 0.13; // within ~8 words of a surah start
+const SURAH_OPENING_BONUS_MID = 0.06; // within ~20 words
+
+// Recited before/between suwar but not part of the followed text. Spoken
+// forms (standard orthography); matched fuzzily, consumed silently.
+const SKIP_PHRASES: string[][] = [
+  ["اعوذ", "بالله", "من", "الشيطان", "الرجيم"],
+  ["بسم", "الله", "الرحمن", "الرحيم"],
+];
+
+interface SkipProgress {
+  phrase: number;
+  pos: number;
+}
+
+interface TrackerState {
+  phase: TrackerPhase;
+  /** seq of the last matched word (locked mode). */
+  anchor: number;
+  misses: number;
+  missBuf: string[];
+  searchBuf: string[];
+  skip: SkipProgress | null;
+  /** Last confidently known position, used to prefer nearby candidates. */
+  lastKnownSeq: number | null;
+}
+
+interface CandidateScore {
+  start: number;
+  matched: number;
+  ratio: number;
+  avgSim: number;
+  firstMatchedSeq: number;
+  lastMatchedSeq: number;
+  score: number;
+}
+
+function initialState(): TrackerState {
+  return {
+    phase: "searching",
+    anchor: -1,
+    misses: 0,
+    missBuf: [],
+    searchBuf: [],
+    skip: null,
+    lastKnownSeq: null,
+  };
+}
+
+function cloneState(s: TrackerState): TrackerState {
+  return {
+    ...s,
+    missBuf: [...s.missBuf],
+    searchBuf: [...s.searchBuf],
+    skip: s.skip ? { ...s.skip } : null,
+  };
+}
+
+export class RecitationTracker {
+  private index: RecitationIndex;
+  private state: TrackerState = initialState();
+  private consumedFinalWords = 0;
+  /** surah number -> seq of its first word. */
+  private surahStartSeq = new Map<number, number>();
+
+  constructor(index: RecitationIndex) {
+    this.index = index;
+    for (const w of index.words) {
+      if (!this.surahStartSeq.has(w.surah)) {
+        this.surahStartSeq.set(w.surah, w.seq);
+      }
+    }
+  }
+
+  reset(): void {
+    this.state = initialState();
+    this.consumedFinalWords = 0;
+  }
+
+  /**
+   * Feed the full final transcript (append-only across the session) and the
+   * current interim tail. Returns the tracker's best position estimate.
+   */
+  feed(finalText: string, interimText: string): TrackerResult {
+    const finalWords = tokenizeArabic(finalText);
+    for (let i = this.consumedFinalWords; i < finalWords.length; i++) {
+      this.step(this.state, finalWords[i]);
+    }
+    this.consumedFinalWords = finalWords.length;
+
+    let effective = this.state;
+    const interimWords = interimText ? tokenizeArabic(interimText) : [];
+    if (interimWords.length > 0) {
+      effective = cloneState(this.state);
+      for (const w of interimWords) this.step(effective, w);
+    }
+    return this.result(effective);
+  }
+
+  private result(s: TrackerState): TrackerResult {
+    if (s.phase === "locked" && s.anchor >= 0) {
+      const word = this.index.words[s.anchor];
+      const ayah =
+        this.index.ayahByKey.get(ayahKey(word.surah, word.ayah)) ?? null;
+      return { phase: "locked", word, ayah };
+    }
+    return { phase: "searching", word: null, ayah: null };
+  }
+
+  private step(s: TrackerState, w: string): void {
+    if (s.phase === "locked") {
+      if (this.tryFollow(s, w)) return;
+      if (this.trySkipPhrase(s, w, false)) return;
+      s.misses++;
+      s.missBuf.push(w);
+      if (s.missBuf.length > MISS_BUF_MAX) s.missBuf.shift();
+      if (s.misses >= MAX_MISSES) {
+        s.phase = "searching";
+        s.lastKnownSeq = s.anchor;
+        s.searchBuf = [...s.missBuf];
+        s.missBuf = [];
+        s.misses = 0;
+        this.attemptLock(s);
+      }
+      return;
+    }
+
+    // searching
+    if (this.trySkipPhrase(s, w, s.searchBuf.length === 0)) return;
+    s.searchBuf.push(w);
+    if (s.searchBuf.length > SEARCH_BUF_MAX) s.searchBuf.shift();
+    this.attemptLock(s);
+  }
+
+  /** Follow mode: match against the next few index words. */
+  private tryFollow(s: TrackerState, w: string): boolean {
+    const words = this.index.words;
+    const from = s.anchor + 1;
+    const to = Math.min(s.anchor + LOOKAHEAD, words.length - 1);
+    for (let j = from; j <= to; j++) {
+      if (isWordMatch(w, words[j].norm)) {
+        s.anchor = j;
+        s.misses = 0;
+        s.missBuf = [];
+        s.skip = null;
+        return true;
+      }
+    }
+    // Recognizers occasionally emit the same word twice (elongations);
+    // allow an exact re-match of the current word without advancing.
+    if (s.anchor >= 0 && words[s.anchor].norm === w) {
+      s.misses = 0;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Advance through isti'adha/basmallah. New phrases may only begin when
+   * `allowStart` (idle search) or while one is already in progress — never
+   * mid-content, so ayah words like اعوذ (Al-Falaq) aren't swallowed.
+   */
+  private trySkipPhrase(
+    s: TrackerState,
+    w: string,
+    allowStart: boolean
+  ): boolean {
+    if (s.skip) {
+      const phrase = SKIP_PHRASES[s.skip.phrase];
+      if (isWordMatch(w, phrase[s.skip.pos])) {
+        s.skip.pos++;
+        if (s.skip.pos >= phrase.length) s.skip = null;
+        return true;
+      }
+      s.skip = null;
+      // fall through: maybe this word starts the other phrase
+    } else if (!allowStart) {
+      return false;
+    }
+    for (let p = 0; p < SKIP_PHRASES.length; p++) {
+      if (isWordMatch(w, SKIP_PHRASES[p][0])) {
+        s.skip = { phrase: p, pos: 1 };
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Global search: try to locate the buffered words in the mushaf. */
+  private attemptLock(s: TrackerState): void {
+    const buf = s.searchBuf;
+    if (buf.length < MIN_LOCK_MATCHES) return;
+
+    const candidates = this.collectCandidates(buf);
+    if (candidates.size === 0) return;
+
+    const scored: CandidateScore[] = [];
+    for (const start of candidates) {
+      const cand = this.alignAt(buf, start);
+      if (cand) scored.push(cand);
+    }
+    if (scored.length === 0) return;
+
+    // Different candidate starts can align onto the same words (junk offsets
+    // shift the start), so location identity is the first matched seq.
+    let best = scored[0];
+    for (const cand of scored) {
+      if (this.adjustedScore(s, cand) > this.adjustedScore(s, best)) {
+        best = cand;
+      }
+    }
+    if (
+      best.matched < MIN_LOCK_MATCHES ||
+      best.ratio < MIN_LOCK_RATIO ||
+      best.avgSim < MIN_LOCK_AVG_SIM
+    ) {
+      return;
+    }
+    let second: CandidateScore | null = null;
+    for (const cand of scored) {
+      if (
+        Math.abs(cand.firstMatchedSeq - best.firstMatchedSeq) >
+          SAME_REGION_SEQS &&
+        (!second || this.adjustedScore(s, cand) > this.adjustedScore(s, second))
+      ) {
+        second = cand;
+      }
+    }
+    if (
+      second &&
+      this.adjustedScore(s, best) - this.adjustedScore(s, second) < LOCK_MARGIN
+    ) {
+      return; // ambiguous (repeated phrase) — wait for more words
+    }
+
+    s.phase = "locked";
+    s.anchor = best.lastMatchedSeq;
+    s.lastKnownSeq = best.lastMatchedSeq;
+    s.misses = 0;
+    s.missBuf = [];
+    s.searchBuf = [];
+    s.skip = null;
+  }
+
+  /**
+   * Candidate score plus context priors: proximity to the last known
+   * position while re-locating, or the surah-opening prior on a cold start.
+   */
+  private adjustedScore(s: TrackerState, cand: CandidateScore): number {
+    if (s.lastKnownSeq !== null) {
+      const d = Math.abs(cand.firstMatchedSeq - s.lastKnownSeq);
+      return cand.score + 0.1 * Math.exp(-d / 1500);
+    }
+    const word = this.index.words[cand.firstMatchedSeq];
+    const surahStart = this.surahStartSeq.get(word.surah);
+    if (surahStart !== undefined) {
+      const d = cand.firstMatchedSeq - surahStart;
+      if (d <= 8) return cand.score + SURAH_OPENING_BONUS_NEAR;
+      if (d <= 20) return cand.score + SURAH_OPENING_BONUS_MID;
+    }
+    return cand.score;
+  }
+
+  private collectCandidates(buf: string[]): Set<number> {
+    const { positionsByNorm } = this.index;
+    const candidates = new Set<number>();
+    // Seed from the rarest words first so the cap keeps the best seeds.
+    const seeds = buf
+      .map((w, i) => ({ w, i, df: positionsByNorm.get(w)?.length ?? 0 }))
+      .filter((x) => x.df > 0 && x.df <= SEED_DF_CAP)
+      .sort((a, b) => a.df - b.df);
+    for (const { w, i } of seeds) {
+      const seqs = positionsByNorm.get(w)!;
+      for (const seq of seqs) {
+        const start = seq - i;
+        candidates.add(start < 0 ? 0 : start);
+        if (candidates.size >= CANDIDATE_CAP) return candidates;
+      }
+    }
+    return candidates;
+  }
+
+  /** Greedy alignment of the buffer against index words from `start`. */
+  private alignAt(buf: string[], start: number): CandidateScore | null {
+    const words = this.index.words;
+    if (start >= words.length) return null;
+    let cursor = start;
+    let matched = 0;
+    let simSum = 0;
+    let firstMatchedSeq = -1;
+    let lastMatchedSeq = -1;
+    for (const w of buf) {
+      // Leading junk (muqatta'at read letter-by-letter, noise) shifts the
+      // reconstructed start, so the first match scans a wide window; after
+      // that the alignment is tight.
+      const span = matched === 0 ? buf.length + 3 : ALIGN_SKIP;
+      const limit = Math.min(cursor + span, words.length - 1);
+      for (let j = cursor; j <= limit; j++) {
+        if (isWordMatch(w, words[j].norm)) {
+          matched++;
+          simSum += wordSimilarity(w, words[j].norm);
+          if (firstMatchedSeq < 0) firstMatchedSeq = j;
+          lastMatchedSeq = j;
+          cursor = j + 1;
+          break;
+        }
+      }
+      // unmatched spoken word: treat as noise, cursor stays
+    }
+    if (matched === 0) return null;
+    const ratio = matched / buf.length;
+    const avgSim = simSum / matched;
+    return {
+      start,
+      matched,
+      ratio,
+      avgSim,
+      firstMatchedSeq,
+      lastMatchedSeq,
+      score: ratio * avgSim,
+    };
+  }
+}

--- a/app/quran/recitation/indexer.ts
+++ b/app/quran/recitation/indexer.ts
@@ -1,0 +1,162 @@
+/**
+ * Builds a word-level recitation index from the mushaf page data served by
+ * /api/quran. Works on the raw html_content strings with regexes (the data
+ * is machine-generated and uniform), so it runs in node and in the browser
+ * without a DOM.
+ *
+ * Word ids mirror the mushaf's own numbering: each line's spans (words AND
+ * ayah-number markers, in document order) are numbered sequentially from the
+ * line's data-first-word-id. The reader page computes the same ids when
+ * rendering, which is what lets the engine target specific spans for
+ * highlighting.
+ */
+
+import { normalizeArabicWord } from "./arabic";
+
+export interface QuranPagesData {
+  [pageNumber: string]: { html_content: string };
+}
+
+export interface IndexedWord {
+  /** Position in the words array (mushaf reading order, markers excluded). */
+  seq: number;
+  /** Global mushaf span id (words + markers), used for highlighting. */
+  id: number;
+  /** Normalized skeleton text used for matching. */
+  norm: string;
+  surah: number;
+  ayah: number;
+  page: number;
+}
+
+export interface AyahInfo {
+  surah: number;
+  ayah: number;
+  /** Page where the ayah starts. */
+  page: number;
+  startSeq: number;
+  endSeq: number;
+  /** Span id range covering the ayah's words and its number marker. */
+  startId: number;
+  endId: number;
+}
+
+export interface RecitationIndex {
+  words: IndexedWord[];
+  ayahs: AyahInfo[];
+  ayahByKey: Map<string, AyahInfo>;
+  /** normalized word -> seqs where it occurs (for search seeding). */
+  positionsByNorm: Map<string, number[]>;
+}
+
+export function ayahKey(surah: number, ayah: number): string {
+  return `${surah}:${ayah}`;
+}
+
+const TOKEN_RE =
+  /<span class=['"]surah-name-v4 me-2['"]>surah(\d+)<\/span>|<p class=['"]quran-line[^>]*?data-first-word-id=['"](\d+)['"][^>]*?>|<span class="word[^"]*"[^>]*><span class="text"[^>]*>([^<]*)<\/span><\/span>|<span class="arabic-num-marker"[^>]*>([^<]*)<\/span>/g;
+
+function parseArabicIndicNumber(text: string): number | null {
+  let value = 0;
+  let sawDigit = false;
+  for (const ch of text) {
+    const code = ch.charCodeAt(0);
+    if (code >= 0x0660 && code <= 0x0669) {
+      value = value * 10 + (code - 0x0660);
+      sawDigit = true;
+    } else if (code >= 0x06f0 && code <= 0x06f9) {
+      value = value * 10 + (code - 0x06f0);
+      sawDigit = true;
+    }
+  }
+  return sawDigit ? value : null;
+}
+
+export function buildRecitationIndex(pages: QuranPagesData): RecitationIndex {
+  const words: IndexedWord[] = [];
+  const ayahs: AyahInfo[] = [];
+  const ayahByKey = new Map<string, AyahInfo>();
+  const positionsByNorm = new Map<string, number[]>();
+
+  let currentSurah = 0;
+  let currentId = 0;
+  // Words seen since the last ayah marker; they belong to the next marker's
+  // ayah. May span page boundaries.
+  let pending: { norm: string; id: number; page: number }[] = [];
+
+  const pushWord = (norm: string, id: number, page: number) => {
+    if (norm) pending.push({ norm, id, page });
+  };
+
+  const flushAyah = (ayahNumber: number, markerId: number) => {
+    if (pending.length === 0) return;
+    const startSeq = words.length;
+    for (const w of pending) {
+      const seq = words.length;
+      words.push({
+        seq,
+        id: w.id,
+        norm: w.norm,
+        surah: currentSurah,
+        ayah: ayahNumber,
+        page: w.page,
+      });
+      const positions = positionsByNorm.get(w.norm);
+      if (positions) positions.push(seq);
+      else positionsByNorm.set(w.norm, [seq]);
+    }
+    const info: AyahInfo = {
+      surah: currentSurah,
+      ayah: ayahNumber,
+      page: pending[0].page,
+      startSeq,
+      endSeq: words.length - 1,
+      startId: pending[0].id,
+      endId: markerId,
+    };
+    ayahs.push(info);
+    ayahByKey.set(ayahKey(currentSurah, ayahNumber), info);
+    pending = [];
+  };
+
+  const pageNumbers = Object.keys(pages)
+    .map((p) => parseInt(p, 10))
+    .filter((p) => !isNaN(p))
+    .sort((a, b) => a - b);
+
+  for (const pageNum of pageNumbers) {
+    const html = pages[String(pageNum)]?.html_content;
+    if (!html) continue;
+    TOKEN_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = TOKEN_RE.exec(html)) !== null) {
+      const [, surahNum, firstWordId, wordText, markerText] = m;
+      if (surahNum !== undefined) {
+        currentSurah = parseInt(surahNum, 10);
+      } else if (firstWordId !== undefined) {
+        currentId = parseInt(firstWordId, 10);
+      } else if (wordText !== undefined) {
+        const norm = normalizeArabicWord(wordText);
+        // Spans holding only waqf/ornament marks (ۖ ۚ ۞ ۩ ...) carry no
+        // letters and do not consume a word id in the mushaf numbering.
+        if (norm) {
+          pushWord(norm, currentId, pageNum);
+          currentId++;
+        }
+      } else if (markerText !== undefined) {
+        const markerId = currentId;
+        currentId++;
+        const ayahNumber = parseArabicIndicNumber(markerText);
+        if (ayahNumber === null) continue; // decorative marker (۞ etc.)
+        flushAyah(ayahNumber, markerId);
+        // Rare data quirk: the next ayah's first word glued after the
+        // digits inside the marker span (e.g. "٢٤٣مَّن"). Keep it as a
+        // word of the next ayah, sharing the marker's span id.
+        const trailing = normalizeArabicWord(markerText);
+        if (trailing) pushWord(trailing, markerId, pageNum);
+      }
+    }
+  }
+
+  return { words, ayahs, ayahByKey, positionsByNorm };
+}

--- a/app/quran/recitation/speech.ts
+++ b/app/quran/recitation/speech.ts
@@ -1,0 +1,244 @@
+/**
+ * Thin wrapper around the Web Speech API for continuous Arabic recitation
+ * capture. Chrome/Edge/Safari expose it (mostly as webkitSpeechRecognition);
+ * Firefox does not.
+ *
+ * Browsers silently end continuous sessions (silence timeouts, ~60s caps,
+ * iOS quirks), so the wrapper auto-restarts while active and carries the
+ * accumulated final transcript across restarts. The engine consumes the
+ * final text append-only, so downstream nothing notices restarts.
+ */
+
+// Minimal Web Speech API typings (not part of TS dom lib).
+interface SpeechRecognitionAlternativeLike {
+  transcript: string;
+}
+interface SpeechRecognitionResultLike {
+  isFinal: boolean;
+  0: SpeechRecognitionAlternativeLike;
+  length: number;
+}
+interface SpeechRecognitionEventLike {
+  resultIndex: number;
+  results: {
+    length: number;
+    [index: number]: SpeechRecognitionResultLike;
+  };
+}
+interface SpeechRecognitionErrorEventLike {
+  error: string;
+}
+export interface SpeechRecognitionLike {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  onresult: ((e: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((e: SpeechRecognitionErrorEventLike) => void) | null;
+  onend: (() => void) | null;
+  onstart?: (() => void) | null;
+  onaudiostart?: (() => void) | null;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+    /** Test seam: lets dev tooling substitute a scripted recognizer. */
+    __qhFakeSpeechCtor?: SpeechRecognitionCtor;
+  }
+}
+
+function getCtor(): SpeechRecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  return (
+    window.__qhFakeSpeechCtor ??
+    window.SpeechRecognition ??
+    window.webkitSpeechRecognition ??
+    null
+  );
+}
+
+export function isSpeechRecognitionSupported(): boolean {
+  return getCtor() !== null;
+}
+
+export type MicPermissionState = "granted" | "denied" | "prompt" | "unknown";
+
+/**
+ * Best-effort microphone permission probe via the Permissions API. Safari
+ * and some browsers don't expose the "microphone" permission name — they
+ * report "unknown" and the recognizer's own prompt/error flow takes over.
+ */
+export async function queryMicrophonePermission(): Promise<MicPermissionState> {
+  if (typeof navigator === "undefined" || !navigator.permissions?.query) {
+    return "unknown";
+  }
+  try {
+    const status = await navigator.permissions.query({
+      name: "microphone" as PermissionName,
+    });
+    if (status.state === "granted" || status.state === "denied") {
+      return status.state;
+    }
+    return "prompt";
+  } catch {
+    return "unknown";
+  }
+}
+
+export interface SpeechSessionCallbacks {
+  /** Full final transcript so far + the current volatile interim tail. */
+  onTranscript: (finalText: string, interimText: string) => void;
+  /** Unrecoverable failure; the session is stopped when this fires. */
+  onFatalError: (message: string) => void;
+  /**
+   * Recognition actually began (permission granted, audio flowing). Fires
+   * once per underlying instance; treat as idempotent.
+   */
+  onCaptureStart?: () => void;
+}
+
+export interface SpeechSession {
+  start(): void;
+  stop(): void;
+}
+
+const RESTART_DELAY_MS = 250;
+const MAX_SILENT_RESTARTS = 6; // consecutive restarts with no results
+
+export function createSpeechSession(
+  cb: SpeechSessionCallbacks,
+  lang = "ar-SA"
+): SpeechSession | null {
+  const Ctor = getCtor();
+  if (!Ctor) return null;
+
+  let active = false;
+  let recognition: SpeechRecognitionLike | null = null;
+  /** Finals accumulated in completed recognition instances. */
+  let committedFinal = "";
+  /** Finals within the current recognition instance. */
+  let instanceFinal = "";
+  let gotResultsThisInstance = false;
+  let silentRestarts = 0;
+  let restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const fail = (message: string) => {
+    active = false;
+    if (restartTimer) clearTimeout(restartTimer);
+    try {
+      recognition?.abort();
+    } catch {
+      // already stopped
+    }
+    recognition = null;
+    cb.onFatalError(message);
+  };
+
+  const spin = () => {
+    if (!active) return;
+    // A fresh instance per (re)start: reusing one after `onend` misbehaves
+    // on iOS Safari.
+    const rec = new Ctor();
+    recognition = rec;
+    rec.lang = lang;
+    rec.continuous = true;
+    rec.interimResults = true;
+    rec.maxAlternatives = 1;
+    instanceFinal = "";
+    gotResultsThisInstance = false;
+
+    const captureStarted = () => {
+      if (!active || recognition !== rec) return;
+      cb.onCaptureStart?.();
+    };
+    rec.onstart = captureStarted;
+    rec.onaudiostart = captureStarted;
+
+    rec.onresult = (e) => {
+      if (!active || recognition !== rec) return;
+      gotResultsThisInstance = true;
+      silentRestarts = 0;
+      let finals = "";
+      let interim = "";
+      for (let i = 0; i < e.results.length; i++) {
+        const res = e.results[i];
+        const text = res[0]?.transcript ?? "";
+        if (res.isFinal) finals += ` ${text}`;
+        else interim += ` ${text}`;
+      }
+      instanceFinal = finals;
+      cb.onTranscript(committedFinal + instanceFinal, interim);
+    };
+
+    rec.onerror = (e) => {
+      if (!active || recognition !== rec) return;
+      switch (e.error) {
+        case "not-allowed":
+        case "service-not-allowed":
+          fail(
+            "Microphone access is blocked. Allow the microphone for this site (padlock icon in the address bar) and try again."
+          );
+          break;
+        case "audio-capture":
+          fail("No microphone was found. Check your audio input and try again.");
+          break;
+        default:
+          // no-speech / aborted / network blips: onend fires next and the
+          // session restarts.
+          break;
+      }
+    };
+
+    rec.onend = () => {
+      if (!active || recognition !== rec) return;
+      committedFinal += instanceFinal;
+      instanceFinal = "";
+      if (!gotResultsThisInstance) {
+        silentRestarts++;
+        if (silentRestarts >= MAX_SILENT_RESTARTS) {
+          fail(
+            "Speech recognition keeps stopping. Check your connection and microphone, then try again."
+          );
+          return;
+        }
+      }
+      restartTimer = setTimeout(spin, RESTART_DELAY_MS);
+    };
+
+    try {
+      rec.start();
+    } catch {
+      // start() throws if called while another instance is winding down;
+      // retry shortly.
+      restartTimer = setTimeout(spin, RESTART_DELAY_MS * 2);
+    }
+  };
+
+  return {
+    start() {
+      if (active) return;
+      active = true;
+      committedFinal = "";
+      instanceFinal = "";
+      silentRestarts = 0;
+      spin();
+    },
+    stop() {
+      active = false;
+      if (restartTimer) clearTimeout(restartTimer);
+      const rec = recognition;
+      recognition = null;
+      try {
+        rec?.abort();
+      } catch {
+        // already stopped
+      }
+    },
+  };
+}

--- a/app/quran/recitation/useRecitationFollower.ts
+++ b/app/quran/recitation/useRecitationFollower.ts
@@ -1,0 +1,198 @@
+"use client";
+
+/**
+ * React hook wiring the speech session to the recitation tracker.
+ *
+ * The caller supplies the built RecitationIndex (or null while it is being
+ * prepared). While the user wants to listen and the index is ready, a
+ * speech session runs; each transcript update advances the tracker and the
+ * snapshot exposes the current position for highlighting/navigation.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RecitationTracker } from "./engine";
+import type { RecitationIndex } from "./indexer";
+import {
+  createSpeechSession,
+  isSpeechRecognitionSupported,
+  queryMicrophonePermission,
+  type SpeechSession,
+} from "./speech";
+
+export type FollowerStatus = "idle" | "preparing" | "listening" | "error";
+
+export interface FollowerSnapshot {
+  status: FollowerStatus;
+  /** null until listening; searching until a location locks. */
+  phase: "searching" | "locked" | null;
+  surah: number | null;
+  ayah: number | null;
+  /** Page of the currently recited word (jump target). */
+  page: number | null;
+  /** Span id of the current word (word-level highlight + scroll target). */
+  wordId: number | null;
+  /** Span id range of the current ayah (ayah highlight). */
+  ayahStartId: number | null;
+  ayahEndId: number | null;
+  /** Last few words heard, for the status pill. */
+  tail: string;
+  /** True once the recognizer is actually capturing audio (mic granted). */
+  micActive: boolean;
+  error: string | null;
+}
+
+const IDLE: FollowerSnapshot = {
+  status: "idle",
+  phase: null,
+  surah: null,
+  ayah: null,
+  page: null,
+  wordId: null,
+  ayahStartId: null,
+  ayahEndId: null,
+  tail: "",
+  micActive: false,
+  error: null,
+};
+
+const MIC_BLOCKED_MESSAGE =
+  "Microphone access is blocked. Allow the microphone for this site (padlock icon in the address bar) and try again.";
+
+function tailOf(finalText: string, interimText: string, words = 5): string {
+  const all = `${finalText} ${interimText}`.trim().split(/\s+/);
+  return all.slice(-words).join(" ");
+}
+
+export function useRecitationFollower(index: RecitationIndex | null) {
+  const [wantListening, setWantListening] = useState(false);
+  const [snapshot, setSnapshot] = useState<FollowerSnapshot>(IDLE);
+  const sessionRef = useRef<SpeechSession | null>(null);
+  // Written by the speech callback (outside React), read by effects.
+  const snapshotRef = useRef<FollowerSnapshot>(IDLE);
+  // Invalidates in-flight start() permission checks when stop() is called.
+  const startTokenRef = useRef(0);
+
+  const update = useCallback((next: FollowerSnapshot) => {
+    const prev = snapshotRef.current;
+    if (
+      prev.status === next.status &&
+      prev.phase === next.phase &&
+      prev.wordId === next.wordId &&
+      prev.surah === next.surah &&
+      prev.ayah === next.ayah &&
+      prev.page === next.page &&
+      prev.tail === next.tail &&
+      prev.micActive === next.micActive &&
+      prev.error === next.error
+    ) {
+      return;
+    }
+    snapshotRef.current = next;
+    setSnapshot(next);
+  }, []);
+
+  useEffect(() => {
+    if (!wantListening) return;
+    if (!index) {
+      update({ ...IDLE, status: "preparing" });
+      return;
+    }
+
+    const tracker = new RecitationTracker(index);
+    const session = createSpeechSession({
+      onCaptureStart: () => {
+        const prev = snapshotRef.current;
+        if (prev.status === "listening" && !prev.micActive) {
+          update({ ...prev, micActive: true });
+        }
+      },
+      onTranscript: (finalText, interimText) => {
+        const r = tracker.feed(finalText, interimText);
+        const tail = tailOf(finalText, interimText);
+        if (r.phase === "locked" && r.word && r.ayah) {
+          update({
+            status: "listening",
+            phase: "locked",
+            surah: r.word.surah,
+            ayah: r.word.ayah,
+            page: r.word.page,
+            wordId: r.word.id,
+            ayahStartId: r.ayah.startId,
+            ayahEndId: r.ayah.endId,
+            tail,
+            micActive: true,
+            error: null,
+          });
+        } else {
+          // keep the last locked position visible while re-searching
+          const prev = snapshotRef.current;
+          update({
+            ...prev,
+            status: "listening",
+            phase: "searching",
+            tail,
+            micActive: true,
+            error: null,
+          });
+        }
+      },
+      onFatalError: (message) => {
+        setWantListening(false);
+        update({ ...IDLE, status: "error", error: message });
+      },
+    });
+
+    if (!session) {
+      setWantListening(false);
+      update({
+        ...IDLE,
+        status: "error",
+        error:
+          "Speech recognition is not supported in this browser. Try Chrome, Edge or Safari.",
+      });
+      return;
+    }
+
+    sessionRef.current = session;
+    update({ ...IDLE, status: "listening", phase: "searching" });
+    session.start();
+
+    return () => {
+      sessionRef.current = null;
+      session.stop();
+    };
+  }, [wantListening, index, update]);
+
+  const start = useCallback(() => {
+    if (!isSpeechRecognitionSupported()) {
+      update({
+        ...IDLE,
+        status: "error",
+        error:
+          "Speech recognition is not supported in this browser. Try Chrome, Edge or Safari.",
+      });
+      return;
+    }
+    update({ ...IDLE, status: "preparing" });
+    // Pre-check the mic permission so an already-denied state gets clear
+    // guidance immediately instead of a dead-looking session. "prompt" and
+    // "unknown" proceed — the recognizer itself asks the user.
+    const token = ++startTokenRef.current;
+    void queryMicrophonePermission().then((perm) => {
+      if (token !== startTokenRef.current) return; // stopped meanwhile
+      if (perm === "denied") {
+        update({ ...IDLE, status: "error", error: MIC_BLOCKED_MESSAGE });
+        return;
+      }
+      setWantListening(true);
+    });
+  }, [update]);
+
+  const stop = useCallback(() => {
+    startTokenRef.current++;
+    setWantListening(false);
+    update(IDLE);
+  }, [update]);
+
+  return { snapshot, listening: wantListening, start, stop };
+}

--- a/app/quran/styles.css
+++ b/app/quran/styles.css
@@ -230,3 +230,36 @@
 .dark .red-text{
   color: #ff6b6b;
 }
+
+/* Recitation follow-along highlights */
+#mushaf-display .word .text {
+  border-radius: 5px;
+  padding: 0 2px;
+  transition: background-color 0.25s ease;
+}
+
+#mushaf-display .word.recited-ayah .text {
+  background-color: rgba(70, 172, 113, 0.16);
+}
+
+#mushaf-display .word.recited-word .text {
+  background-color: rgba(70, 172, 113, 0.45);
+}
+
+#mushaf-display .arabic-num-marker.recited-ayah {
+  background-color: rgba(70, 172, 113, 0.16);
+  border-radius: 5px;
+  transition: background-color 0.25s ease;
+}
+
+.dark #mushaf-display .word.recited-ayah .text {
+  background-color: rgba(70, 172, 113, 0.28);
+}
+
+.dark #mushaf-display .word.recited-word .text {
+  background-color: rgba(70, 172, 113, 0.55);
+}
+
+.dark #mushaf-display .arabic-num-marker.recited-ayah {
+  background-color: rgba(70, 172, 113, 0.28);
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -112,11 +112,9 @@ const nextConfig: NextConfig = {
       permanent: true,
     },
   ],
-  experimental: {
-    turbo: {
-      rules: {
-        "*.mp3": ["file-loader"],
-      },
+  turbopack: {
+    rules: {
+      "*.mp3": ["file-loader"],
     },
   },
   webpack: (config: CustomWebpackConfig, { isServer }) => {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "22.x"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
@@ -31,11 +34,11 @@
     "framer-motion": "^11.18.1",
     "lucide-react": "^0.459.0",
     "music-metadata": "^11.2.3",
-    "next": "15.0.3",
+    "next": "15.5.20",
     "nodemailer": "^7.0.3",
     "prettier": "^3.3.3",
-    "react": "19.0.0-rc-66855b96-20241106",
-    "react-dom": "19.0.0-rc-66855b96-20241106",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
     "react-icons": "^5.4.0",
     "react-markdown": "^10.0.0",
     "tailwind-merge": "^2.5.4",
@@ -48,7 +51,7 @@
     "@types/react-dom": "^18",
     "@types/webpack": "^5.28.5",
     "eslint": "^9.14.0",
-    "eslint-config-next": "15.0.3",
+    "eslint-config-next": "15.5.20",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:recitation": "tsx scripts/test-recitation.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.828.0",
@@ -51,6 +52,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",
+    "tsx": "^4.23.0",
     "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,34 +16,34 @@ importers:
         version: 3.844.0(@aws-sdk/client-s3@3.844.0)
       '@next/third-parties':
         specifier: ^15.3.5
-        version: 15.3.5(next@15.0.3(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 15.3.5(next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog':
         specifier: ^1.1.2
-        version: 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-navigation-menu':
         specifier: ^1.2.1
-        version: 1.2.13(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.2.13(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-popover':
         specifier: ^1.1.14
-        version: 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.2
-        version: 1.2.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.2.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-select':
         specifier: ^2.2.5
-        version: 2.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 2.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slider':
         specifier: ^1.2.1
-        version: 1.3.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.3.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
-        version: 1.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+        version: 1.2.3(@types/react@18.3.23)(react@19.2.7)
       '@radix-ui/react-toast':
         specifier: ^1.2.13
-        version: 1.2.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.2.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-toggle':
         specifier: ^1.1.0
-        version: 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       basic-ftp:
         specifier: ^5.0.5
         version: 5.0.5
@@ -55,22 +55,22 @@ importers:
         version: 2.1.1
       cmdk:
         specifier: ^1.1.1
-        version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 1.1.1(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
       framer-motion:
         specifier: ^11.18.1
-        version: 11.18.2(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        version: 11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react:
         specifier: ^0.459.0
-        version: 0.459.0(react@19.0.0-rc-66855b96-20241106)
+        version: 0.459.0(react@19.2.7)
       music-metadata:
         specifier: ^11.2.3
         version: 11.6.0
       next:
-        specifier: 15.0.3
-        version: 15.0.3(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+        specifier: 15.5.20
+        version: 15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       nodemailer:
         specifier: ^7.0.3
         version: 7.0.5
@@ -78,17 +78,17 @@ importers:
         specifier: ^3.3.3
         version: 3.6.2
       react:
-        specifier: 19.0.0-rc-66855b96-20241106
-        version: 19.0.0-rc-66855b96-20241106
+        specifier: 19.2.7
+        version: 19.2.7
       react-dom:
-        specifier: 19.0.0-rc-66855b96-20241106
-        version: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       react-icons:
         specifier: ^5.4.0
-        version: 5.5.0(react@19.0.0-rc-66855b96-20241106)
+        version: 5.5.0(react@19.2.7)
       react-markdown:
         specifier: ^10.0.0
-        version: 10.1.0(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+        version: 10.1.0(@types/react@18.3.23)(react@19.2.7)
       tailwind-merge:
         specifier: ^2.5.4
         version: 2.6.0
@@ -115,8 +115,8 @@ importers:
         specifier: ^9.14.0
         version: 9.31.0(jiti@1.21.7)
       eslint-config-next:
-        specifier: 15.0.3
-        version: 15.0.3(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3)
+        specifier: 15.5.20
+        version: 15.5.20(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3)
       postcss:
         specifier: ^8
         version: 8.5.6
@@ -302,6 +302,9 @@ packages:
 
   '@emnapi/core@1.4.4':
     resolution: {integrity: sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/runtime@1.4.4':
     resolution: {integrity: sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==}
@@ -538,119 +541,155 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@img/sharp-darwin-arm64@0.33.5':
-    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.33.5':
-    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
-    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
-    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
-    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
-    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
-    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
-    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
-    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
-    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linux-arm64@0.33.5':
-    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm@0.33.5':
-    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.33.5':
-    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-x64@0.33.5':
-    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
-    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
-    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-wasm32@0.33.5':
-    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-ia32@0.33.5':
-    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.33.5':
-    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -681,60 +720,60 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@15.0.3':
-    resolution: {integrity: sha512-t9Xy32pjNOvVn2AS+Utt6VmyrshbpfUMhIjFO60gI58deSo/KgLOp31XZ4O+kY/Is8WAGYwA5gR7kOb1eORDBA==}
+  '@next/env@15.5.20':
+    resolution: {integrity: sha512-dXh51Wvddf8daEyBXryZZEe1FdVxEWx9lgaTseLZUtC1XP/W8Wri+Z+VPOElHlByk23CyqHdc2oVByX7wsTWsw==}
 
-  '@next/eslint-plugin-next@15.0.3':
-    resolution: {integrity: sha512-3Ln/nHq2V+v8uIaxCR6YfYo7ceRgZNXfTd3yW1ukTaFbO+/I8jNakrjYWODvG9BuR2v5kgVtH/C8r0i11quOgw==}
+  '@next/eslint-plugin-next@15.5.20':
+    resolution: {integrity: sha512-MZUgFpVd9rGSZpb8bNceUWvkAZe6aQw/6h2SSqHQuYzKfaiEUEVPIO6mXqaBmiBEBSN1f1sOc1uV8GCM90oegg==}
 
-  '@next/swc-darwin-arm64@15.0.3':
-    resolution: {integrity: sha512-s3Q/NOorCsLYdCKvQlWU+a+GeAd3C8Rb3L1YnetsgwXzhc3UTWrtQpB/3eCjFOdGUj5QmXfRak12uocd1ZiiQw==}
+  '@next/swc-darwin-arm64@15.5.20':
+    resolution: {integrity: sha512-in0yXG7/pRBVjWeEl7f7ZZETpletSMFKXVS4GJgHENTPVrJFNJKPrYewa9rpZcvdjwFece5fZP0CK34G4PxowA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.0.3':
-    resolution: {integrity: sha512-Zxl/TwyXVZPCFSf0u2BNj5sE0F2uR6iSKxWpq4Wlk/Sv9Ob6YCKByQTkV2y6BCic+fkabp9190hyrDdPA/dNrw==}
+  '@next/swc-darwin-x64@15.5.20':
+    resolution: {integrity: sha512-0hsFshdPnTzGJdDTHeHJ+XPUShOpnyp9pUFDwDhqctsA0Cd8NcIVGRPtptYhgYY9DjkKgCDRkXxmgRc+CgT5Wg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.0.3':
-    resolution: {integrity: sha512-T5+gg2EwpsY3OoaLxUIofmMb7ohAUlcNZW0fPQ6YAutaWJaxt1Z1h+8zdl4FRIOr5ABAAhXtBcpkZNwUcKI2fw==}
+  '@next/swc-linux-arm64-gnu@15.5.20':
+    resolution: {integrity: sha512-DMvkoBtAABOzE6pMZRW/xNm7sKqql3wzzzZJ1R/d/rp4BCxv6LykouD3tHjGY8WdQqGpZs11t+R9AtjPxvvljw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@15.0.3':
-    resolution: {integrity: sha512-WkAk6R60mwDjH4lG/JBpb2xHl2/0Vj0ZRu1TIzWuOYfQ9tt9NFsIinI1Epma77JVgy81F32X/AeD+B2cBu/YQA==}
+  '@next/swc-linux-arm64-musl@15.5.20':
+    resolution: {integrity: sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@15.0.3':
-    resolution: {integrity: sha512-gWL/Cta1aPVqIGgDb6nxkqy06DkwJ9gAnKORdHWX1QBbSZZB+biFYPFti8aKIQL7otCE1pjyPaXpFzGeG2OS2w==}
+  '@next/swc-linux-x64-gnu@15.5.20':
+    resolution: {integrity: sha512-DkWLEdKajJwdGt27M3i1VEO2kelTvZrK6Pcb7JvW2BY+nofWm7FBsBNDj7g7Pr1NuQ5PLJvqEqYa20GTsBDnKQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@15.0.3':
-    resolution: {integrity: sha512-QQEMwFd8r7C0GxQS62Zcdy6GKx999I/rTO2ubdXEe+MlZk9ZiinsrjwoiBL5/57tfyjikgh6GOU2WRQVUej3UA==}
+  '@next/swc-linux-x64-musl@15.5.20':
+    resolution: {integrity: sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@15.0.3':
-    resolution: {integrity: sha512-9TEp47AAd/ms9fPNgtgnT7F3M1Hf7koIYYWCMQ9neOwjbVWJsHZxrFbI3iEDJ8rf1TDGpmHbKxXf2IFpAvheIQ==}
+  '@next/swc-win32-arm64-msvc@15.5.20':
+    resolution: {integrity: sha512-Hp3zFsN8N8Kj9+vY6L4vnZ9EtA9eXyATu0q4EfGbZTiocgPUNSfz8NWhym6xvaOmHpJ8EuoypuU1WejCPsTFtg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.0.3':
-    resolution: {integrity: sha512-VNAz+HN4OGgvZs6MOoVfnn41kBzT+M+tB+OK4cww6DNyWS6wKaDpaAm/qLeOUbnMh0oVx1+mg0uoYARF69dJyA==}
+  '@next/swc-win32-x64-msvc@15.5.20':
+    resolution: {integrity: sha512-T/L7CXpR1M0wij/xbF3rT1+7KvSkfOLr7C+ToHHWZTG2eKmb52C5WvsyGCBNtkVvDEUESWkRUbbqSH4rSbOCYQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1340,11 +1379,8 @@ packages:
     resolution: {integrity: sha512-slcr1wdRbX7NFphXZOxtxRNA7hXAAtJAXJDE/wdoMAos27SIquVCKiSqfB6/28YzQ8FCsB5NKkhdM5gMADbqxg==}
     engines: {node: '>=18.0.0'}
 
-  '@swc/counter@0.1.3':
-    resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/helpers@0.5.13':
-    resolution: {integrity: sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==}
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -1816,10 +1852,6 @@ packages:
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
-  busboy@1.6.0:
-    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
-    engines: {node: '>=10.16.0'}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1892,13 +1924,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1982,8 +2007,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  detect-libc@2.0.4:
-    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
@@ -2078,8 +2103,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@15.0.3:
-    resolution: {integrity: sha512-IGP2DdQQrgjcr4mwFPve4DrCqo7CVVez1WoYY47XwKSrYO4hC0Dlb+iJA60i0YfICOzgNADIb8r28BpQ5Zs0wg==}
+  eslint-config-next@15.5.20:
+    resolution: {integrity: sha512-Pl/I5544gmkcVVWcnaOMfhJSBK8lZ1NCJ+mGBkd2qvbGt2Gi7sEpgHF06OR13a2p6THODlncpvGsZzY2vUqwxw==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0 || ^9.0.0
       typescript: '>=3.3.1'
@@ -2437,9 +2462,6 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
-
-  is-arrayish@0.3.2:
-    resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -2819,17 +2841,16 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next@15.0.3:
-    resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
+  next@15.5.20:
+    resolution: {integrity: sha512-cvyS3/geydan1xLtE3FA8VCgdoQ/Gg/dlOldFkFCbB5VcVYJV7090hQLBnvTW2PwT76Z/dHdzDZCsVhZpoOlUA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
+      '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-66855b96-20241106
-      react-dom: ^18.2.0 || 19.0.0-rc-66855b96-20241106
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -3022,10 +3043,10 @@ packages:
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
-  react-dom@19.0.0-rc-66855b96-20241106:
-    resolution: {integrity: sha512-D25vdaytZ1wFIRiwNU98NPQ/upS2P8Co4/oNoa02PzHbh8deWdepjm5qwZM/46OdSiGv4WSWwxP55RO9obqJEQ==}
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: ^19.2.7
 
   react-icons@5.5.0:
     resolution: {integrity: sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==}
@@ -3071,8 +3092,8 @@ packages:
       '@types/react':
         optional: true
 
-  react@19.0.0-rc-66855b96-20241106:
-    resolution: {integrity: sha512-klH7xkT71SxRCx4hb1hly5FJB21Hz0ACyxbXYAECEqssUjtJeFUAaI2U1DgJAzkGEnvEm3DkxuBchMC/9K4ipg==}
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -3142,8 +3163,8 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
-  scheduler@0.25.0-rc-66855b96-20241106:
-    resolution: {integrity: sha512-HQXp/Mnp/MMRSXMQF7urNFla+gmtXW/Gr1KliuR0iboTit4KvZRY8KYaq5ccCTAOJiUqQh2rE2F3wgUekmgdlA==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@4.3.2:
     resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
@@ -3155,6 +3176,11 @@ packages:
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3173,8 +3199,8 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.33.5:
-    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
@@ -3205,9 +3231,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-swizzle@0.2.2:
-    resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3231,10 +3254,6 @@ packages:
 
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
-
-  streamsearch@1.1.0:
-    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
-    engines: {node: '>=10.0.0'}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -4093,6 +4112,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.4':
     dependencies:
       tslib: 2.8.1
@@ -4234,11 +4258,11 @@ snapshots:
       '@floating-ui/core': 1.7.2
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.4(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@floating-ui/react-dom@2.1.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@floating-ui/dom': 1.7.2
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.10': {}
 
@@ -4255,79 +4279,101 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/sharp-darwin-arm64@0.33.5':
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.33.5':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.0.4':
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.0.4':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.0.4':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.0.5':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.0.4':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.0.4':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-linux-arm64@0.33.5':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.33.5':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.33.5':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.33.5':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.33.5':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.33.5':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.33.5':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.4.4
+      '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-win32-ia32@0.33.5':
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-x64@0.33.5':
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -4370,40 +4416,40 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@next/env@15.0.3': {}
+  '@next/env@15.5.20': {}
 
-  '@next/eslint-plugin-next@15.0.3':
+  '@next/eslint-plugin-next@15.5.20':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.0.3':
+  '@next/swc-darwin-arm64@15.5.20':
     optional: true
 
-  '@next/swc-darwin-x64@15.0.3':
+  '@next/swc-darwin-x64@15.5.20':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.0.3':
+  '@next/swc-linux-arm64-gnu@15.5.20':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.0.3':
+  '@next/swc-linux-arm64-musl@15.5.20':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.0.3':
+  '@next/swc-linux-x64-gnu@15.5.20':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.0.3':
+  '@next/swc-linux-x64-musl@15.5.20':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.0.3':
+  '@next/swc-win32-arm64-msvc@15.5.20':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.0.3':
+  '@next/swc-win32-x64-msvc@15.5.20':
     optional: true
 
-  '@next/third-parties@15.3.5(next@15.0.3(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@next/third-parties@15.3.5(next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     dependencies:
-      next: 15.0.3(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
+      next: 15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
       third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4427,358 +4473,358 @@ snapshots:
 
   '@radix-ui/primitive@1.1.2': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-context@1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-dialog@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-dialog@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-direction@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-focus-guards@1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-focus-guards@1.1.2(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-id@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-id@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-navigation-menu@1.2.13(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-navigation-menu@1.2.13(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-popover@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-popover@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-popper': 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-popper@1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-popper@1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.4(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      '@floating-ui/react-dom': 2.1.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.23)(react@19.2.7)
       '@radix-ui/rect': 1.1.1
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-presence@1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-presence@1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-    optionalDependencies:
-      '@types/react': 18.3.23
-      '@types/react-dom': 18.3.7(@types/react@18.3.23)
-
-  '@radix-ui/react-select@2.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-popper': 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
+  '@radix-ui/react-select@2.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-popper': 1.2.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       aria-hidden: 1.2.6
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-slider@1.3.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-slider@1.3.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.1
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-slot@1.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-slot@1.2.3(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-toast@1.2.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-toast@1.2.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-toggle@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-toggle@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.23)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
       '@types/react': 18.3.23
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
@@ -5122,9 +5168,7 @@ snapshots:
       '@smithy/types': 4.3.1
       tslib: 2.8.1
 
-  '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.13':
+  '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
 
@@ -5638,10 +5682,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  busboy@1.6.0:
-    dependencies:
-      streamsearch: 1.1.0
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -5702,14 +5742,14 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cmdk@1.1.1(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
+  cmdk@1.1.1(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -5719,18 +5759,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
-    optional: true
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
-    optional: true
 
   comma-separated-tokens@2.0.3: {}
 
@@ -5802,7 +5830,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@2.0.4:
+  detect-libc@2.1.2:
     optional: true
 
   detect-node-es@1.1.0: {}
@@ -5978,9 +6006,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.0.3(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3):
+  eslint-config-next@15.5.20(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3):
     dependencies:
-      '@next/eslint-plugin-next': 15.0.3
+      '@next/eslint-plugin-next': 15.5.20
       '@rushstack/eslint-patch': 1.12.0
       '@typescript-eslint/eslint-plugin': 8.36.0(@typescript-eslint/parser@8.36.0(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3)
       '@typescript-eslint/parser': 8.36.0(eslint@9.31.0(jiti@1.21.7))(typescript@5.8.3)
@@ -6264,14 +6292,14 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  framer-motion@11.18.2(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
+  framer-motion@11.18.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       motion-dom: 11.18.1
       motion-utils: 11.18.1
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   fsevents@2.3.3:
     optional: true
@@ -6434,9 +6462,6 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
-
-  is-arrayish@0.3.2:
-    optional: true
 
   is-async-function@2.1.1:
     dependencies:
@@ -6644,9 +6669,9 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lucide-react@0.459.0(react@19.0.0-rc-66855b96-20241106):
+  lucide-react@0.459.0(react@19.2.7):
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
 
   make-error@1.3.6: {}
 
@@ -6938,27 +6963,25 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@15.0.3(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106):
+  next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 15.0.3
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.13
-      busboy: 1.6.0
+      '@next/env': 15.5.20
+      '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001727
       postcss: 8.4.31
-      react: 19.0.0-rc-66855b96-20241106
-      react-dom: 19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106)
-      styled-jsx: 5.1.6(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.0.3
-      '@next/swc-darwin-x64': 15.0.3
-      '@next/swc-linux-arm64-gnu': 15.0.3
-      '@next/swc-linux-arm64-musl': 15.0.3
-      '@next/swc-linux-x64-gnu': 15.0.3
-      '@next/swc-linux-x64-musl': 15.0.3
-      '@next/swc-win32-arm64-msvc': 15.0.3
-      '@next/swc-win32-x64-msvc': 15.0.3
-      sharp: 0.33.5
+      '@next/swc-darwin-arm64': 15.5.20
+      '@next/swc-darwin-x64': 15.5.20
+      '@next/swc-linux-arm64-gnu': 15.5.20
+      '@next/swc-linux-arm64-musl': 15.5.20
+      '@next/swc-linux-x64-gnu': 15.5.20
+      '@next/swc-linux-x64-musl': 15.5.20
+      '@next/swc-win32-arm64-msvc': 15.5.20
+      '@next/swc-win32-x64-msvc': 15.5.20
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -7139,18 +7162,18 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106):
+  react-dom@19.2.7(react@19.2.7):
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
-      scheduler: 0.25.0-rc-66855b96-20241106
+      react: 19.2.7
+      scheduler: 0.27.0
 
-  react-icons@5.5.0(react@19.0.0-rc-66855b96-20241106):
+  react-icons@5.5.0(react@19.2.7):
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
 
   react-is@16.13.1: {}
 
-  react-markdown@10.1.0(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106):
+  react-markdown@10.1.0(@types/react@18.3.23)(react@19.2.7):
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
@@ -7159,7 +7182,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       mdast-util-to-hast: 13.2.0
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       unified: 11.0.5
@@ -7168,34 +7191,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-remove-scroll-bar@2.3.8(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106):
+  react-remove-scroll-bar@2.3.8(@types/react@18.3.23)(react@19.2.7):
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
-      react-style-singleton: 2.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-style-singleton: 2.2.3(@types/react@18.3.23)(react@19.2.7)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.23
 
-  react-remove-scroll@2.7.1(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106):
+  react-remove-scroll@2.7.1(@types/react@18.3.23)(react@19.2.7):
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
-      react-remove-scroll-bar: 2.3.8(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      react-style-singleton: 2.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@18.3.23)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@18.3.23)(react@19.2.7)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
-      use-sidecar: 1.1.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106)
+      use-callback-ref: 1.3.3(@types/react@18.3.23)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@18.3.23)(react@19.2.7)
     optionalDependencies:
       '@types/react': 18.3.23
 
-  react-style-singleton@2.2.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106):
+  react-style-singleton@2.2.3(@types/react@18.3.23)(react@19.2.7):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.23
 
-  react@19.0.0-rc-66855b96-20241106: {}
+  react@19.2.7: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -7293,7 +7316,7 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
-  scheduler@0.25.0-rc-66855b96-20241106: {}
+  scheduler@0.27.0: {}
 
   schema-utils@4.3.2:
     dependencies:
@@ -7305,6 +7328,9 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
+
+  semver@7.8.5:
+    optional: true
 
   serialize-javascript@6.0.2:
     dependencies:
@@ -7332,31 +7358,36 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  sharp@0.33.5:
+  sharp@0.34.5:
     dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.4
-      semver: 7.7.2
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.33.5
-      '@img/sharp-darwin-x64': 0.33.5
-      '@img/sharp-libvips-darwin-arm64': 1.0.4
-      '@img/sharp-libvips-darwin-x64': 1.0.4
-      '@img/sharp-libvips-linux-arm': 1.0.5
-      '@img/sharp-libvips-linux-arm64': 1.0.4
-      '@img/sharp-libvips-linux-s390x': 1.0.4
-      '@img/sharp-libvips-linux-x64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
-      '@img/sharp-linux-arm': 0.33.5
-      '@img/sharp-linux-arm64': 0.33.5
-      '@img/sharp-linux-s390x': 0.33.5
-      '@img/sharp-linux-x64': 0.33.5
-      '@img/sharp-linuxmusl-arm64': 0.33.5
-      '@img/sharp-linuxmusl-x64': 0.33.5
-      '@img/sharp-wasm32': 0.33.5
-      '@img/sharp-win32-ia32': 0.33.5
-      '@img/sharp-win32-x64': 0.33.5
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@2.0.0:
@@ -7395,11 +7426,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-swizzle@0.2.2:
-    dependencies:
-      is-arrayish: 0.3.2
-    optional: true
-
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -7422,8 +7448,6 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  streamsearch@1.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -7522,10 +7546,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  styled-jsx@5.1.6(react@19.0.0-rc-66855b96-20241106):
+  styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
 
   sucrase@3.35.0:
     dependencies:
@@ -7782,17 +7806,17 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106):
+  use-callback-ref@1.3.3(@types/react@18.3.23)(react@19.2.7):
     dependencies:
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.23
 
-  use-sidecar@1.1.3(@types/react@18.3.23)(react@19.0.0-rc-66855b96-20241106):
+  use-sidecar@1.1.3(@types/react@18.3.23)(react@19.2.7):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.0.0-rc-66855b96-20241106
+      react: 19.2.7
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.23

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.7)(typescript@5.8.3)
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
       typescript:
         specifier: ^5
         version: 5.8.3
@@ -306,6 +309,162 @@ packages:
   '@emnapi/wasi-threads@1.0.3':
     resolution: {integrity: sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==}
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -405,67 +564,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -533,24 +704,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.0.3':
     resolution: {integrity: sha512-WkAk6R60mwDjH4lG/JBpb2xHl2/0Vj0ZRu1TIzWuOYfQ9tt9NFsIinI1Epma77JVgy81F32X/AeD+B2cBu/YQA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.0.3':
     resolution: {integrity: sha512-gWL/Cta1aPVqIGgDb6nxkqy06DkwJ9gAnKORdHWX1QBbSZZB+biFYPFti8aKIQL7otCE1pjyPaXpFzGeG2OS2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.0.3':
     resolution: {integrity: sha512-QQEMwFd8r7C0GxQS62Zcdy6GKx999I/rTO2ubdXEe+MlZk9ZiinsrjwoiBL5/57tfyjikgh6GOU2WRQVUej3UA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.0.3':
     resolution: {integrity: sha512-9TEp47AAd/ms9fPNgtgnT7F3M1Hf7koIYYWCMQ9neOwjbVWJsHZxrFbI3iEDJ8rf1TDGpmHbKxXf2IFpAvheIQ==}
@@ -1035,6 +1210,7 @@ packages:
   '@smithy/middleware-endpoint@4.1.14':
     resolution: {integrity: sha512-+BGLpK5D93gCcSEceaaYhUD/+OCGXM1IDaq/jKUQ+ujB0PTWlWN85noodKw/IPFZhIKFCNEe19PGd/reUMeLSQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: Please upgrade to @smithy/middleware-endpoint@4.1.15 or higher to fix a bug preventing the resolution of ENV and config file custom endpoints https://github.com/smithy-lang/smithy-typescript/issues/1645
 
   '@smithy/middleware-retry@4.1.15':
     resolution: {integrity: sha512-iKYUJpiyTQ33U2KlOZeUb0GwtzWR3C0soYcKuCnTmJrvt6XwTPQZhMfsjJZNw7PpQ3TU4Ati1qLSrkSJxnnSMQ==}
@@ -1312,6 +1488,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -1352,41 +1529,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1601,6 +1786,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1879,6 +2065,11 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -2151,6 +2342,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@14.0.0:
@@ -2630,6 +2822,7 @@ packages:
   next@15.0.3:
     resolution: {integrity: sha512-ontCbCRKJUIoivAdGB34yCaOcPgYXr9AAkV/IwqFfWWTXEPUgLYkSkqBhIk9KK7gGmgjc64B+RdoeIDM13Irnw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -3234,6 +3427,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -3325,6 +3523,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -3902,6 +4101,84 @@ snapshots:
   '@emnapi/wasi-threads@1.0.3':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.31.0(jiti@1.21.7))':
@@ -5668,6 +5945,35 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -7352,6 +7658,12 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.23.0:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: false
+  sharp: false
+  unrs-resolver: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# Single-package repo. The explicit packages list keeps pnpm 9 (used by some
+# deploy platforms) happy; allowBuilds answers pnpm 11's build-script gate
+# (all three ship prebuilt binaries, so their install scripts are unneeded).
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: false
   sharp: false

--- a/scripts/test-recitation.ts
+++ b/scripts/test-recitation.ts
@@ -1,0 +1,384 @@
+/**
+ * Recitation follow-along test suite. Runs against the real mushaf data in
+ * app/quran/data, exercising the normalizer, indexer and tracking engine
+ * with speech-recognition-style transcripts (standard orthography, noise,
+ * interim churn).
+ *
+ *   pnpm test:recitation
+ */
+
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import {
+  normalizeArabicWord,
+  tokenizeArabic,
+  levenshtein,
+  isWordMatch,
+} from "../app/quran/recitation/arabic";
+import {
+  buildRecitationIndex,
+  ayahKey,
+  type RecitationIndex,
+} from "../app/quran/recitation/indexer";
+import {
+  RecitationTracker,
+  type TrackerResult,
+} from "../app/quran/recitation/engine";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, "..", "app", "quran", "data");
+
+let passed = 0;
+let failed = 0;
+const failures: string[] = [];
+
+function check(name: string, cond: boolean, detail?: string) {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    failed++;
+    const msg = `  ✗ ${name}${detail ? ` — ${detail}` : ""}`;
+    failures.push(msg);
+    console.error(msg);
+  }
+}
+
+function section(title: string) {
+  console.log(`\n=== ${title} ===`);
+}
+
+function loadPages(file: string) {
+  const raw = readFileSync(path.join(DATA_DIR, file), "utf8");
+  return JSON.parse(raw).pages;
+}
+
+function fmt(r: TrackerResult): string {
+  if (r.phase !== "locked" || !r.word) return "searching";
+  return `${r.word.surah}:${r.word.ayah} (page ${r.word.page}, seq ${r.word.seq})`;
+}
+
+/** Feed a transcript to a fresh tracker word-by-word as final text. */
+function recite(index: RecitationIndex, text: string): TrackerResult {
+  const tracker = new RecitationTracker(index);
+  return feedInto(tracker, text);
+}
+
+/** Feed text incrementally (simulates finals arriving in chunks). */
+function feedInto(tracker: RecitationTracker, text: string): TrackerResult {
+  const words = text.trim().split(/\s+/);
+  let acc = "";
+  let last: TrackerResult = tracker.feed("", "");
+  for (const w of words) {
+    acc = acc ? `${acc} ${w}` : w;
+    last = tracker.feed(acc, "");
+  }
+  return last;
+}
+
+// ---------------------------------------------------------------------------
+section("normalization");
+{
+  const cases: Array<[string, string, string]> = [
+    ["ٱلْحَمْدُ", "الحمد", "hamzat wasl + harakat"],
+    ["ٱلْعَـٰلَمِينَ", "العالمين", "dagger alef -> full alef"],
+    ["ٱلصِّرَٰطَ", "الصراط", "dagger alef in sirat"],
+    ["ٱلرَّحْمَـٰنِ", "الرحمان", "rahman keeps long vowel"],
+    ["مَـٰلِكِ", "مالك", "malik"],
+    ["ءَامَنُوا۟", "امنوا", "initial hamza+alef, silent-mark waw kept"],
+    ["أُو۟لَـٰٓئِكَ", "اولايك", "ulaika skeleton"],
+    ["ٱلصَّلَوٰةَ", "الصلواه", "salah with dagger + ta marbuta"],
+    ["إِبْرَٰهِـۧمَ", "ابراهيم", "small high yeh restored"],
+    ["دَاوُۥدَ", "داوود", "small waw restored"],
+    ["يُؤْمِنُونَ", "يومنون", "waw hamza mapped"],
+    ["شَىْءٍ", "شي", "alef maqsura + hamza dropped"],
+    ["﴿١٢٣﴾", "", "digits/symbols stripped"],
+  ];
+  for (const [input, expected, label] of cases) {
+    const got = normalizeArabicWord(input);
+    check(`normalize ${label}`, got === expected, `got "${got}" want "${expected}"`);
+  }
+  check(
+    "tokenize drops empties",
+    tokenizeArabic("بِسْمِ ٱللَّهِ ١ ، الم").join("|") === "بسم|الله|الم"
+  );
+  check("levenshtein basic", levenshtein("الرحمن", "الرحمان") === 1);
+  check("short words exact only", !isWordMatch("من", "ما"));
+  check("fuzzy match rahman", isWordMatch("الرحمن", "الرحمان"));
+}
+
+// ---------------------------------------------------------------------------
+section("index integrity (hafs)");
+const hafsPages = loadPages("data_hafs.json");
+const t0 = Date.now();
+const hafs = buildRecitationIndex(hafsPages);
+const buildMs = Date.now() - t0;
+{
+  console.log(
+    `  built in ${buildMs}ms — ${hafs.words.length} words, ${hafs.ayahs.length} ayahs`
+  );
+  check("6236 ayahs", hafs.ayahs.length === 6236, `got ${hafs.ayahs.length}`);
+  check(
+    "word count plausible",
+    hafs.words.length > 76000 && hafs.words.length < 79000,
+    `got ${hafs.words.length}`
+  );
+  check("build under 2s", buildMs < 2000, `${buildMs}ms`);
+
+  const surahs = new Set(hafs.words.map((w) => w.surah));
+  check("114 surahs", surahs.size === 114, `got ${surahs.size}`);
+
+  const fatiha1 = hafs.ayahByKey.get(ayahKey(1, 1))!;
+  const fatihaText = hafs.words
+    .slice(fatiha1.startSeq, fatiha1.endSeq + 1)
+    .map((w) => w.norm)
+    .join(" ");
+  check(
+    "1:1 text",
+    fatihaText === "بسم الله الرحمان الرحيم",
+    `got "${fatihaText}"`
+  );
+  check("1:1 on page 1", fatiha1.page === 1);
+  check("1:1 ids 1..5", fatiha1.startId === 1 && fatiha1.endId === 5,
+    `got ${fatiha1.startId}..${fatiha1.endId}`);
+
+  const kursi = hafs.ayahByKey.get(ayahKey(2, 255))!;
+  check("2:255 exists on page 42", kursi.page === 42, `got page ${kursi.page}`);
+
+  const lastAyah = hafs.ayahByKey.get(ayahKey(114, 6))!;
+  check("114:6 present, page 604", lastAyah.page === 604, `got ${lastAyah?.page}`);
+
+  // Waqf-mark spans (ۖ ۚ ...) must not consume word ids: on page 2 line 3
+  // the mushaf numbers الم=37 ١=38 ذلك=39 الكتاب=40 لا=41 ريب=42 [ۛ] فيه=43
+  const baqara2 = hafs.ayahByKey.get(ayahKey(2, 2))!;
+  const fihi = hafs.words
+    .slice(baqara2.startSeq, baqara2.endSeq + 1)
+    .find((w) => w.norm === "فيه");
+  check("waqf spans skip ids (2:2 فيه id=43)", fihi?.id === 43, `got ${fihi?.id}`);
+  check("2:2 starts at id 39", baqara2.startId === 39, `got ${baqara2.startId}`);
+
+  // every ayah's marker id should be >= its last word id
+  let ranges = true;
+  for (const a of hafs.ayahs) {
+    if (a.endId < a.startId) ranges = false;
+  }
+  check("ayah id ranges valid", ranges);
+}
+
+// ---------------------------------------------------------------------------
+section("cold lock + follow (Fatiha)");
+{
+  const tracker = new RecitationTracker(hafs);
+  let r = feedInto(tracker, "الحمد لله رب العالمين");
+  check("locks 1:2", fmt(r).startsWith("1:2"), fmt(r));
+  r = feedInto(tracker, "الرحمن الرحيم");
+  check("follows to 1:3", fmt(r).startsWith("1:3"), fmt(r));
+  r = feedInto(tracker, "مالك يوم الدين");
+  check("follows to 1:4", fmt(r).startsWith("1:4"), fmt(r));
+  r = feedInto(tracker, "اياك نعبد واياك نستعين");
+  check("follows to 1:5", fmt(r).startsWith("1:5"), fmt(r));
+  r = feedInto(
+    tracker,
+    "اهدنا الصراط المستقيم صراط الذين انعمت عليهم غير المغضوب عليهم ولا الضالين"
+  );
+  check("follows to 1:7", fmt(r).startsWith("1:7"), fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("isti'adha + basmallah then Baqara (muqatta'at junk)");
+{
+  const tracker = new RecitationTracker(hafs);
+  // ASR typically renders الم as spelled-out letters or noise
+  const r = feedInto(
+    tracker,
+    "اعوذ بالله من الشيطان الرجيم بسم الله الرحمن الرحيم الف لام ميم ذلك الكتاب لا ريب فيه هدى للمتقين"
+  );
+  check("locks in 2:2", fmt(r).startsWith("2:2 "), fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("global jump to Ayat al-Kursi");
+{
+  const tracker = new RecitationTracker(hafs);
+  feedInto(tracker, "قل هو الله احد الله الصمد");
+  const before = feedInto(tracker, "");
+  check("locked in 112", before.word?.surah === 112, fmt(before));
+  // reciter jumps: misses accumulate, re-search, re-lock
+  const r = feedInto(
+    tracker,
+    "الله لا اله الا هو الحي القيوم لا تاخذه سنه ولا نوم"
+  );
+  check("re-locks at 2:255", fmt(r).startsWith("2:255"), fmt(r));
+  check("page 42", r.word?.page === 42, `page ${r.word?.page}`);
+}
+
+// ---------------------------------------------------------------------------
+section("repeated phrase (Ar-Rahman refrain)");
+{
+  const tracker = new RecitationTracker(hafs);
+  // The refrain alone appears 31 times — must NOT lock on it blindly
+  let r = feedInto(tracker, "فباي الاء ربكما تكذبان");
+  check("refrain alone stays ambiguous", r.phase === "searching", fmt(r));
+  // Continuing with a unique following ayah disambiguates:
+  // 55:13 refrain then 55:14 "خلق الانسان من صلصال كالفخار"
+  r = feedInto(tracker, "خلق الانسان من صلصال كالفخار");
+  check("disambiguates to 55:14", fmt(r).startsWith("55:14"), fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("same-surah identical refrain follows in reading order");
+{
+  // Ar-Rahman's refrain is identical 31 times within ONE surah. Once locked,
+  // follow mode must advance to the NEXT occurrence, never jump to another.
+  const tracker = new RecitationTracker(hafs);
+  let r = feedInto(
+    tracker,
+    "فباي الاء ربكما تكذبان خلق الانسان من صلصال كالفخار وخلق الجان من مارج من نار"
+  );
+  check("locks 55:15 via refrain + context", fmt(r).startsWith("55:15"), fmt(r));
+  r = feedInto(tracker, "فباي الاء ربكما تكذبان");
+  check("refrain again advances to 55:16 (next in order)", fmt(r).startsWith("55:16"), fmt(r));
+  r = feedInto(tracker, "يا معشر الجن والانس ان استطعتم ان تنفذوا من اقطار السماوات والارض فانفذوا");
+  check("continues into 55:33", fmt(r).startsWith("55:33"), fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("identical ayahs stay ambiguous (2:5 == 31:5)");
+{
+  const tracker = new RecitationTracker(hafs);
+  const r = feedInto(tracker, "اولئك على هدى من ربهم واولئك هم المفلحون");
+  check("identical-ayah recitation does not lock", r.phase === "searching", fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("cross-page follow (page 2 -> 3 boundary)");
+{
+  const tracker = new RecitationTracker(hafs);
+  // 2:4 (unique context) then 2:5 then 2:6 which starts page 3
+  let r = feedInto(
+    tracker,
+    "والذين يؤمنون بما انزل اليك وما انزل من قبلك وبالاخرة هم يوقنون"
+  );
+  check("locks 2:4", fmt(r).startsWith("2:4 "), fmt(r));
+  r = feedInto(tracker, "اولئك على هدى من ربهم واولئك هم المفلحون");
+  check("follows to 2:5", fmt(r).startsWith("2:5 "), fmt(r));
+  r = feedInto(
+    tracker,
+    "ان الذين كفروا سواء عليهم ءانذرتهم ام لم تنذرهم لا يؤمنون"
+  );
+  check("follows to 2:6 on page 3", fmt(r).startsWith("2:6 "), fmt(r));
+  check("page advanced to 3", r.word?.page === 3, `page ${r.word?.page}`);
+}
+
+// ---------------------------------------------------------------------------
+section("ASR noise tolerance");
+{
+  const tracker = new RecitationTracker(hafs);
+  // Kahf 18:1-2 with typical ASR mangling (missing/approximate words)
+  const r = feedInto(
+    tracker,
+    "الحمد لله الذي انزل على عبده الكتب ولم يجعل له عوجا قيما لينذر باسا شديدا"
+  );
+  check("locks and follows within 18:1-2", r.word?.surah === 18 && (r.word.ayah === 1 || r.word.ayah === 2), fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("interim churn consistency");
+{
+  // Simulates real recognizer behaviour: volatile interim text that mutates
+  // then finalizes. Final position must equal the one-shot result.
+  const t1 = new RecitationTracker(hafs);
+  t1.feed("", "قل هو");
+  t1.feed("", "قل هو الله");
+  t1.feed("", "قل هو الله اح");
+  const rInterim = t1.feed("قل هو الله احد", "");
+  const r2 = t1.feed("قل هو الله احد الله الصمد", "");
+
+  const oneShot = recite(hafs, "قل هو الله احد الله الصمد");
+  check(
+    "interim churn matches one-shot",
+    fmt(r2) === fmt(oneShot),
+    `${fmt(r2)} vs ${fmt(oneShot)}`
+  );
+  console.log(`  (after finals: ${fmt(rInterim)}, one-shot: ${fmt(oneShot)})`);
+}
+
+// ---------------------------------------------------------------------------
+section("backtrack: reciter restarts the ayah");
+{
+  const tracker = new RecitationTracker(hafs);
+  let r = feedInto(tracker, "الله لا اله الا هو الحي القيوم لا تاخذه سنة ولا نوم");
+  check("locked 2:255 mid-ayah", fmt(r).startsWith("2:255"), fmt(r));
+  // reciter goes back and restarts the ayah from its beginning
+  r = feedInto(
+    tracker,
+    "الله لا اله الا هو الحي القيوم لا تاخذه سنة ولا نوم له ما في السماوات وما في الارض"
+  );
+  check(
+    "re-locks in 2:255 after restart (proximity)",
+    fmt(r).startsWith("2:255"),
+    fmt(r)
+  );
+}
+
+// ---------------------------------------------------------------------------
+section("short surah full recitation (Al-Ikhlas 112)");
+{
+  const tracker = new RecitationTracker(hafs);
+  const r = feedInto(
+    tracker,
+    "بسم الله الرحمن الرحيم قل هو الله احد الله الصمد لم يلد ولم يولد ولم يكن له كفوا احد"
+  );
+  check("ends at 112:4", fmt(r).startsWith("112:4"), fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("surah boundary with basmallah skip (114 after 113)");
+{
+  const tracker = new RecitationTracker(hafs);
+  let r = feedInto(
+    tracker,
+    "قل اعوذ برب الفلق من شر ما خلق ومن شر غاسق اذا وقب ومن شر النفاثات في العقد ومن شر حاسد اذا حسد"
+  );
+  check("finishes 113:5", fmt(r).startsWith("113:5"), fmt(r));
+  r = feedInto(
+    tracker,
+    "بسم الله الرحمن الرحيم قل اعوذ برب الناس ملك الناس"
+  );
+  check("crosses into 114:2", fmt(r).startsWith("114:2"), fmt(r));
+}
+
+// ---------------------------------------------------------------------------
+section("hisham index smoke test");
+{
+  const hishamPages = loadPages("data_hisham.json");
+  const hisham = buildRecitationIndex(hishamPages);
+  console.log(`  ${hisham.words.length} words, ${hisham.ayahs.length} ayahs`);
+  check("6226 ayahs (Shami count)", hisham.ayahs.length === 6226, `got ${hisham.ayahs.length}`);
+  const r = recite(hisham, "الحمد لله رب العالمين الرحمن الرحيم");
+  check("locks Fatiha in hisham", r.word?.surah === 1, fmt(r));
+  // the glued marker-word quirk pages
+  const baqara243 = hisham.ayahByKey.get(ayahKey(2, 243));
+  const baqara244 = hisham.ayahByKey.get(ayahKey(2, 244));
+  check("2:243/2:244 exist despite glued marker", !!baqara243 && !!baqara244);
+}
+
+// ---------------------------------------------------------------------------
+section("search performance");
+{
+  const tracker = new RecitationTracker(hafs);
+  const t = Date.now();
+  feedInto(tracker, "ان الله مع الصابرين"); // common words — worst-ish case
+  const ms = Date.now() - t;
+  console.log(`  common-word search took ${ms}ms`);
+  check("search under 500ms", ms < 500, `${ms}ms`);
+}
+
+// ---------------------------------------------------------------------------
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) {
+  console.error("\nFailures:");
+  for (const f of failures) console.error(f);
+  process.exit(1);
+}


### PR DESCRIPTION
## What

A Tarteel-style **follow-along mode** for the Quran reader (`/quran`): press the green **Follow along** button, recite anywhere in the Quran, and the reader identifies the ayah, jumps to its page, highlights the ayah with the current word emphasized, and follows word-by-word as the recitation continues — across ayahs, pages, and surah boundaries.

## How it works

Everything runs client-side; audio goes only to the browser's own speech service (Web Speech API, `ar-SA`, Chrome/Edge/Safari — Firefox gets a clear "not supported" message).

- **`app/quran/recitation/arabic.ts`** — normalizes Uthmani mushaf text and recognizer output into a common skeleton (dagger alef → full alef so `ٱلصِّرَٰطَ` matches spoken `الصراط`, hamza/ta-marbuta folding, waqf-mark stripping) + length-scaled fuzzy word matching.
- **`app/quran/recitation/indexer.ts`** — indexes the already-loaded mushaf JSON (~50-80ms for all 604 pages) into ~77k words with surah/ayah/page and span ids that mirror the mushaf's own `data-first-word-id` numbering (including the waqf-span and glued-marker quirks), so highlights target exact spans. Rebuilds on qiraat/font switch — matching always follows the displayed text, including Hisham/Ibn Dhakwan's Shami ayah numbering.
- **`app/quran/recitation/engine.ts`** — search→lock→follow tracker. Global search seeds candidates from an inverted index and fuzzy-aligns; a **margin test keeps repeated phrases ambiguous** (Ar-Rahman refrain ×31, identical ayahs 2:5/31:5) until following words disambiguate; a cold-start surah-opening prior resolves `الحمد لله رب العالمين` to Fatiha over its 5 mid-surah duplicates; proximity prior favors re-locking near the last position. Once locked, following only scans a ~10-word lookahead window, so identical text elsewhere in the surah can never steal the position. Isti'adha/basmallah are consumed silently; recognition noise is tolerated; ~5 consecutive misses trigger self-healing re-search. Volatile interim transcripts run on a throwaway state copy.
- **`speech.ts` / `useRecitationFollower.ts`** — continuous capture with auto-restart (browsers kill sessions after ~60s) and transcript continuity, microphone-permission pre-check (already-denied shows actionable guidance immediately; "Waiting for microphone…" while the prompt is up), friendly fatal-error mapping, and a `window.__qhFakeSpeechCtor` seam for scripted testing without a mic.
- **`page.tsx` / `styles.css`** — labeled Follow along / Listening button, status pill (state + surah·ayah + heard-words tail), ayah + current-word highlight via span ids, instant follow-scroll with a post-layout re-check, memoized line rendering.

## Testing

- **`pnpm test:recitation`** — 59 checks against the real mushaf data files: index integrity for all qiraat (6236/6226 ayahs, id rules), normalization cases, and engine scenarios — cold locks, global jumps, refrain ambiguity + same-surah refrain ordering, muqatta'at noise, cross-page follow, interim churn vs one-shot equivalence, ayah-restart backtracking, Hisham smoke test.
- Browser-verified end-to-end with a scripted recognizer: cold Fatiha lock with isti'adha/basmallah, page jumps (1→42 Kursi, →440 Ya-Sin, →531 Ar-Rahman), word-level following, qiraat switch mid-listen, session auto-restart continuity, denied/prompt permission flows, stop/dismiss, mobile layout.
- `pnpm lint` and `pnpm build` pass (only pre-existing RadioPlayer warning).

## Notes for review

## Deployment fixes (found while shipping)

Both deploy previews were red, for reasons that turned out to predate or be triggered by this PR:

- **pnpm 9 vs `pnpm-workspace.yaml`** — deploy platforms run pnpm 9 for this repo (lockfile v9 + project age) and pnpm 9 hard-errors on a workspace file without a `packages` field. Fixed by declaring the root as the sole package (installs verified locally on pnpm 9.15.9 / 10.18.3 / 11.7.0).
- **Vercel: "Vulnerable version of Next.js detected"** — Vercel has been rejecting every deployment since April because of known CVEs in Next 15.0.3 (main is red for the same reason). Upgraded `next`/`eslint-config-next` to 15.5.20, moved React from the year-old 19.0.0 RC to stable 19.2.7, migrated the renamed `experimental.turbo` → `turbopack` config key, and pinned `engines.node` to 22.x (Vercel was defaulting to deprecated Node 20). Full local verification re-run on the upgraded stack: typecheck, lint, 59 recitation tests, production build, and a browser smoke test of the reader + follow-along.


- `tsx` added as a devDependency for the test runner; `pnpm-workspace.yaml` pins pnpm 11's `allowBuilds` prompts to `false` (all three packages ship prebuilt binaries).
- `.claude/launch.json` defines the dev-server launch config for tooling previews; drop it from the PR if you'd rather not track it.
- Known limitation: muqatta'at (`الم`…) aren't transcribed by recognizers as written — the engine treats them as noise and locks on the following words.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
